### PR TITLE
Update to build system to match new error format

### DIFF
--- a/ScriptCs.sublime-build
+++ b/ScriptCs.sublime-build
@@ -1,6 +1,6 @@
 {
 	"cmd": ["scriptcs", "$file_name"],
 	"working_dir": "${project_path:${folder}}",
-	"file_regex": "^(.*?): \\(([0-9]+),([0-9]+)\\): ([^\\[]+)",
+	"file_regex": "^(.*?)\\(([0-9]+),([0-9]+)\\): ([^\\[]+)",
 	"selector": "source.csx"	
 }


### PR DESCRIPTION
This fixes the build system so that you can navigate to the correct file/line/column for build errors by hitting F4.
