### PR TITLE
Added -inMemory flag to build system

### DIFF
--- a/ScriptCs.sublime-build
+++ b/ScriptCs.sublime-build
@@ -1,5 +1,5 @@
 {
-	"cmd": ["scriptcs", "$file"],
+	"cmd": ["scriptcs", "$file", "-inMemory"],
 	"file_regex": "^(.*?)\\(([0-9]+),([0-9]+)\\): ([^\\[]+)",
 	"selector": "source.csx"	
 }


### PR DESCRIPTION
When compiling to dll, I get errors that the file is in use. This works at least...
