### PR TITLE
Updated build system to use -cache flag for scriptcs v0.9.0

### DIFF
--- a/ScriptCs.sublime-build
+++ b/ScriptCs.sublime-build
@@ -1,5 +1,5 @@
 {
-	"cmd": ["scriptcs", "$file", "-inMemory"],
+	"cmd": ["scriptcs", "$file", "-cache", "false"],
 	"file_regex": "^(.*?)\\(([0-9]+),([0-9]+)\\): ([^\\[]+)",
-	"selector": "source.csx"	
+	"selector": "source.csx"
 }


### PR DESCRIPTION
Updated the build system in Sublime to use the new -cache false option for scriptcs v0.9.0 instead of older -inMemory option.
