### PR TITLE
Support for svm and correction for scriptcs mono bug #840.

### DIFF
--- a/ScriptCs.sublime-build
+++ b/ScriptCs.sublime-build
@@ -1,5 +1,9 @@
 {
-	"cmd": ["scriptcs", "$file", "-cache", "false"],
+	"cmd": ["scriptcs", "-script",  "$file", "-cache", "false"],
 	"file_regex": "^(.*?)\\(([0-9]+),([0-9]+)\\): ([^\\[]+)",
-	"selector": "source.csx"
+	"selector": "source.csx",
+
+	"windows": {
+		"shell": true
+	}
 }


### PR DESCRIPTION
The `-script` parameter is required for the following scriptcs & mono issue - **Error running scriptcs when the full path to the file is provided [#840](https://github.com/scriptcs/scriptcs/issues/840)**.

On Windows with svm installed, shims are used to hook up the correct version of scriptcs. The shim has a scriptcs.cmd (batch file) entry point. Sublime normally looks for scriptcs.exe to execute. To force Sublime to look for both scriptcs.exe (vanilla install) and scriptcs.cmd (svm install), the `"shell": true` addition is required to the `ScriptCs.sublime-build` file.

This has been tested on Windows with chocolatey installed scriptcs and with svm installed scriptcs. It has been tested on Ubuntu 14.10 with svm installed scriptcs. The `"shell": true` addition is scoped only to the Windows platform.
